### PR TITLE
[CORE-683]: Allow 0 required block confirmations in home

### DIFF
--- a/contracts/upgradeable_contracts/BasicBridge.sol
+++ b/contracts/upgradeable_contracts/BasicBridge.sol
@@ -39,8 +39,12 @@ contract BasicBridge is Initializable, Validatable, Ownable, Upgradeable, Claima
         return uintStorage[GAS_PRICE];
     }
 
+    function validateRequiredBlockConfirmations(uint256 _blockConfirmations) internal returns (bool) {
+        return _blockConfirmations > 0;
+    }
+
     function setRequiredBlockConfirmations(uint256 _blockConfirmations) external onlyOwner {
-        require(_blockConfirmations > 0);
+        require(validateRequiredBlockConfirmations(_blockConfirmations));
         uintStorage[REQUIRED_BLOCK_CONFIRMATIONS] = _blockConfirmations;
         emit RequiredBlockConfirmationChanged(_blockConfirmations);
     }

--- a/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/BasicForeignBridgeErcToErc.sol
@@ -16,7 +16,7 @@ contract BasicForeignBridgeErcToErc is BasicForeignBridge {
     ) internal {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
-        require(_requiredBlockConfirmations != 0);
+        require(validateRequiredBlockConfirmations(_requiredBlockConfirmations));
         require(_gasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);
         require(_owner != address(0));

--- a/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
+++ b/contracts/upgradeable_contracts/erc20_to_erc20/HomeBridgeErcToErc.sol
@@ -128,7 +128,7 @@ contract HomeBridgeErcToErc is
     ) internal {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
-        require(_requiredBlockConfirmations > 0);
+        require(validateRequiredBlockConfirmations(_requiredBlockConfirmations));
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));
@@ -148,6 +148,12 @@ contract HomeBridgeErcToErc is
         emit GasPriceChanged(_homeGasPrice);
         emit DailyLimitChanged(_dailyLimit);
         emit ExecutionDailyLimitChanged(_foreignDailyLimit);
+    }
+
+    function validateRequiredBlockConfirmations(
+        uint256 /* _blockConfirmations */
+    ) internal returns (bool) {
+        return true;
     }
 
     function claimTokensFromErc677(address _token, address _to) external onlyIfUpgradeabilityOwner {

--- a/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/ForeignBridgeErcToNative.sol
@@ -18,7 +18,7 @@ contract ForeignBridgeErcToNative is BasicForeignBridge, ERC20Bridge {
     ) external returns (bool) {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
-        require(_requiredBlockConfirmations != 0);
+        require(validateRequiredBlockConfirmations(_requiredBlockConfirmations));
         require(_gasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);
         require(_owner != address(0));

--- a/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
+++ b/contracts/upgradeable_contracts/erc20_to_native/HomeBridgeErcToNative.sol
@@ -141,7 +141,7 @@ contract HomeBridgeErcToNative is
     ) internal {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
-        require(_requiredBlockConfirmations > 0);
+        require(validateRequiredBlockConfirmations(_requiredBlockConfirmations));
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
         require(_blockReward == address(0) || AddressUtils.isContract(_blockReward));
         require(_foreignMaxPerTx < _foreignDailyLimit);

--- a/contracts/upgradeable_contracts/inverted_native_to_erc20/ForeignBridgeInvertedNativeToErc.sol
+++ b/contracts/upgradeable_contracts/inverted_native_to_erc20/ForeignBridgeInvertedNativeToErc.sol
@@ -19,7 +19,7 @@ contract ForeignBridgeInvertedNativeToErc is BasicForeignBridge {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
-        require(_requiredBlockConfirmations > 0);
+        require(validateRequiredBlockConfirmations(_requiredBlockConfirmations));
         require(_foreignGasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);
         require(_owner != address(0));

--- a/contracts/upgradeable_contracts/inverted_native_to_erc20/HomeBridgeInvertedNativeToErc.sol
+++ b/contracts/upgradeable_contracts/inverted_native_to_erc20/HomeBridgeInvertedNativeToErc.sol
@@ -58,7 +58,7 @@ contract HomeBridgeInvertedNativeToErc is
     ) internal {
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
-        require(_requiredBlockConfirmations > 0);
+        require(validateRequiredBlockConfirmations(_requiredBlockConfirmations));
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));
@@ -78,6 +78,12 @@ contract HomeBridgeInvertedNativeToErc is
         emit GasPriceChanged(_homeGasPrice);
         emit DailyLimitChanged(_dailyLimit);
         emit ExecutionDailyLimitChanged(_foreignDailyLimit);
+    }
+
+    function validateRequiredBlockConfirmations(
+        uint256 /* _blockConfirmations */
+    ) internal returns (bool) {
+        return true;
     }
 
     function claimTokensFromErc677(address _token, address _to) external onlyIfUpgradeabilityOwner {

--- a/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/ForeignBridgeNativeToErc.sol
@@ -98,7 +98,7 @@ contract ForeignBridgeNativeToErc is
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
-        require(_requiredBlockConfirmations > 0);
+        require(validateRequiredBlockConfirmations(_requiredBlockConfirmations));
         require(_foreignGasPrice > 0);
         require(_homeMaxPerTx < _homeDailyLimit);
         require(_owner != address(0));

--- a/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
+++ b/contracts/upgradeable_contracts/native_to_erc20/HomeBridgeNativeToErc.sol
@@ -102,7 +102,7 @@ contract HomeBridgeNativeToErc is EternalStorage, BasicHomeBridge, RewardableHom
         require(!isInitialized());
         require(AddressUtils.isContract(_validatorContract));
         require(_homeGasPrice > 0);
-        require(_requiredBlockConfirmations > 0);
+        require(validateRequiredBlockConfirmations(_requiredBlockConfirmations));
         require(_minPerTx > 0 && _maxPerTx > _minPerTx && _dailyLimit > _maxPerTx);
         require(_foreignMaxPerTx < _foreignDailyLimit);
         require(_owner != address(0));

--- a/deploy/src/loadEnv.js
+++ b/deploy/src/loadEnv.js
@@ -212,7 +212,6 @@ const env = envalid.cleanEnv(process.env, validations)
 // Logic validations
 checkValidators(env.VALIDATORS, env.REQUIRED_NUMBER_OF_VALIDATORS)
 checkGasPrices(env.FOREIGN_GAS_PRICE, foreignPrefix)
-checkBlockConfirmations(env.HOME_REQUIRED_BLOCK_CONFIRMATIONS, homePrefix)
 checkBlockConfirmations(env.FOREIGN_REQUIRED_BLOCK_CONFIRMATIONS, foreignPrefix)
 checkLimits(
   env.HOME_MIN_AMOUNT_PER_TX,

--- a/test/erc_to_erc/home_bridge.test.js
+++ b/test/erc_to_erc/home_bridge.test.js
@@ -150,20 +150,6 @@ contract('HomeBridge_ERC20_to_ERC20', async accounts => {
 
       await homeContract
         .initialize(
-          validatorContract.address,
-          '3',
-          '2',
-          '1',
-          gasPrice,
-          0,
-          token.address,
-          foreignDailyLimit,
-          foreignMaxPerTx,
-          owner
-        )
-        .should.be.rejectedWith(ERROR_MSG)
-      await homeContract
-        .initialize(
           owner,
           '3',
           '2',

--- a/test/inverted_native_to_erc/home_bridge.test.js
+++ b/test/inverted_native_to_erc/home_bridge.test.js
@@ -144,20 +144,6 @@ contract('HomeBridge_Inverted_Native_to_ERC20', async accounts => {
 
       await homeContract
         .initialize(
-          validatorContract.address,
-          '3',
-          '2',
-          '1',
-          gasPrice,
-          0,
-          token.address,
-          foreignDailyLimit,
-          foreignMaxPerTx,
-          owner
-        )
-        .should.be.rejectedWith(ERROR_MSG)
-      await homeContract
-        .initialize(
           owner,
           '3',
           '2',


### PR DESCRIPTION
In raft, we have instant finality, so 0 block confirmations are safe.